### PR TITLE
Adjust alarmtrigger log

### DIFF
--- a/ansible/roles/alarmstrigger/tasks/clean.yml
+++ b/ansible/roles/alarmstrigger/tasks/clean.yml
@@ -11,4 +11,4 @@
   file:
     path: "{{ whisk_logs_dir }}/alarmsTrigger"
     state: absent
-  become: true
+  become: "{{ logs.dir.become }}"

--- a/ansible/roles/alarmstrigger/tasks/deploy.yml
+++ b/ansible/roles/alarmstrigger/tasks/deploy.yml
@@ -6,7 +6,7 @@
     path: "{{ whisk_logs_dir }}/alarmsTrigger"
     state: directory
     mode: 0777
-  become: true
+  become: "{{ logs.dir.become }}"
 
 - name: (re)start alarms trigger
   docker_container:


### PR DESCRIPTION
## Description
This adjusts the permissions of the alarmtrigger logs according to the configuration. It only requires root if set by the user.

## Related issue and scope
No issue for this minor change.
It should bring the ansible deployment of the alarm package back to mind ;)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).